### PR TITLE
Correct links after renaming the organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,20 @@
 ##  Secure/Multipurpose Internet Mail Extensions (S/ MIME) Version 3.5 Certificate Handling
 This is the working area for the Individual internet-draft, "Secure/Multipurpose Internet Mail Extensions (S/ MIME) Version 3.5 Certificate Handling".
 
-* [Editor's copy](https://spasm-wg.github.io/smime/draft-schaad-rfc5750-bis.html)
+* [Editor's copy](https://lamps-wg.github.io/smime/draft-schaad-rfc5750-bis.html)
 * [Individual Draft] (https://tools.ietf.org/html/draft-schaad-rfc5750-bis)
-* [Compare Editor's and WG versions](https://tools.ietf.org/rfcdiff?url1=https://www.ietf.org/id/draft-schaad-rfc5750-bis&url2=https://spasm-wg.github.io/smime/draft-schaad-rfc5750-bis.txt)
-* [Compare Editor's and RFC5750] (https://tools.ietf.org/rfcdiff?url1=https://www.ietf.org/rfc/rfc5750.txt&url2=https://spasm-wg.github.io/smime/draft-schaad-rfc5750-bis.txt)
+* [Compare Editor's and WG versions](https://tools.ietf.org/rfcdiff?url1=https://www.ietf.org/id/draft-schaad-rfc5750-bis&url2=https://lamps-wg.github.io/smime/draft-schaad-rfc5750-bis.txt)
+* [Compare Editor's and RFC5750] (https://tools.ietf.org/rfcdiff?url1=https://www.ietf.org/rfc/rfc5750.txt&url2=https://lamps-wg.github.io/smime/draft-schaad-rfc5750-bis.txt)
 
 
 ##  Secure/Multipurpose Internet Mail Extensions (S/ MIME) Version 3.5 Message
 
 This is the working area for the Individual internet-draft, "Secure/Multipurpose Internet Mail Extensions (S/ MIME) Version 3.5 Message".
 
-* [Editor's copy](https://spasm-wg.github.io/smime/draft-schaad-rfc5751-bis.html)
+* [Editor's copy](https://lamps-wg.github.io/smime/draft-schaad-rfc5751-bis.html)
 * [Individual Draft] (https://tools.ietf.org/html/draft-schaad-rfc5751-bis)
-* [Compare Editor's and WG versions](https://tools.ietf.org/rfcdiff?url1=https://www.ietf.org/id/draft-schaad-rfc5751-bis&url2=https://spasm-wg.github.io/smime/draft-schaad-rfc5751-bis.txt)
-* [Compare Editor's and RFC5751] (https://tools.ietf.org/rfcdiff?url1=https://www.ietf.org/rfc/rfc5751.txt&url2=https://spasm-wg.github.io/smime/draft-schaad-rfc5751-bis.txt)
+* [Compare Editor's and WG versions](https://tools.ietf.org/rfcdiff?url1=https://www.ietf.org/id/draft-schaad-rfc5751-bis&url2=https://lamps-wg.github.io/smime/draft-schaad-rfc5751-bis.txt)
+* [Compare Editor's and RFC5751] (https://tools.ietf.org/rfcdiff?url1=https://www.ietf.org/rfc/rfc5751.txt&url2=https://lamps-wg.github.io/smime/draft-schaad-rfc5751-bis.txt)
 
 
 ## Building the Draft
@@ -35,8 +35,8 @@ instructions](https://github.com/martinthomson/i-d-template/blob/master/doc/SETU
 
 Before submitting feedback, please familiarize yourself with our current issues
 list and review the [working group
-documents](https://datatracker.ietf.org/wg/rfc5750/documents/) and [mailing
-list discussion](https://mailarchive.ietf.org/arch/browse/rfc5750/). If you're
+documents](https://datatracker.ietf.org/wg/lamps/documents/) and [mailing
+list discussion](https://mailarchive.ietf.org/arch/search/?email_list=spasm/). If you're
 new to this, you may also want to read the [Tao of the
 IETF](https://www.ietf.org/tao.html).
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is the working area for the Individual internet-draft, "Secure/Multipurpose
 
 * [Editor's copy](https://lamps-wg.github.io/smime/draft-schaad-rfc5750-bis.html)
 * [Individual Draft] (https://tools.ietf.org/html/draft-schaad-rfc5750-bis)
-* [Compare Editor's and WG versions](https://tools.ietf.org/rfcdiff?url1=https://www.ietf.org/id/draft-schaad-rfc5750-bis&url2=https://lamps-wg.github.io/smime/draft-schaad-rfc5750-bis.txt)
+* [Compare Editor's and WG versions](https://tools.ietf.org/rfcdiff?url1=https://www.ietf.org/id/draft-schaad-lamps-rfc5750-bis&url2=https://lamps-wg.github.io/smime/draft-schaad-rfc5750-bis.txt)
 * [Compare Editor's and RFC5750] (https://tools.ietf.org/rfcdiff?url1=https://www.ietf.org/rfc/rfc5750.txt&url2=https://lamps-wg.github.io/smime/draft-schaad-rfc5750-bis.txt)
 
 
@@ -14,8 +14,8 @@ This is the working area for the Individual internet-draft, "Secure/Multipurpose
 This is the working area for the Individual internet-draft, "Secure/Multipurpose Internet Mail Extensions (S/ MIME) Version 3.5 Message".
 
 * [Editor's copy](https://lamps-wg.github.io/smime/draft-schaad-rfc5751-bis.html)
-* [Individual Draft] (https://tools.ietf.org/html/draft-schaad-rfc5751-bis)
-* [Compare Editor's and WG versions](https://tools.ietf.org/rfcdiff?url1=https://www.ietf.org/id/draft-schaad-rfc5751-bis&url2=https://lamps-wg.github.io/smime/draft-schaad-rfc5751-bis.txt)
+* [Working Group Draft] (https://tools.ietf.org/html/draft-ietf-lamps-rfc5751-bis)
+* [Compare Editor's and WG versions](https://tools.ietf.org/rfcdiff?url1=https://www.ietf.org/id/draft-ietf-lamps-rfc5751-bis&url2=https://lamps-wg.github.io/smime/draft-schaad-rfc5751-bis.txt)
 * [Compare Editor's and RFC5751] (https://tools.ietf.org/rfcdiff?url1=https://www.ietf.org/rfc/rfc5751.txt&url2=https://lamps-wg.github.io/smime/draft-schaad-rfc5751-bis.txt)
 
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ This is the working area for the Individual internet-draft, "Secure/Multipurpose
 
 This is the working area for the Individual internet-draft, "Secure/Multipurpose Internet Mail Extensions (S/ MIME) Version 3.5 Message".
 
-* [Editor's copy](https://lamps-wg.github.io/smime/draft-schaad-rfc5751-bis.html)
+* [Editor's copy](https://lamps-wg.github.io/smime/draft-ietf-lamps-rfc5751-bis.html)
 * [Working Group Draft] (https://tools.ietf.org/html/draft-ietf-lamps-rfc5751-bis)
-* [Compare Editor's and WG versions](https://tools.ietf.org/rfcdiff?url1=https://www.ietf.org/id/draft-ietf-lamps-rfc5751-bis&url2=https://lamps-wg.github.io/smime/draft-schaad-rfc5751-bis.txt)
-* [Compare Editor's and RFC5751] (https://tools.ietf.org/rfcdiff?url1=https://www.ietf.org/rfc/rfc5751.txt&url2=https://lamps-wg.github.io/smime/draft-schaad-rfc5751-bis.txt)
+* [Compare Editor's and WG versions](https://tools.ietf.org/rfcdiff?url1=https://www.ietf.org/id/draft-ietf-lamps-rfc5751-bis&url2=https://lamps-wg.github.io/smime/draft-ietf-lamps-rfc5751-bis.txt)
+* [Compare Editor's and RFC5751] (https://tools.ietf.org/rfcdiff?url1=https://www.ietf.org/rfc/rfc5751.txt&url2=https://lamps-wg.github.io/smime/draft-ietf-lamps-rfc5751-bis.txt)
 
 
 ## Building the Draft

--- a/draft-schaad-rfc5750-bis.xml
+++ b/draft-schaad-rfc5750-bis.xml
@@ -271,6 +271,14 @@
    </list>
 </t>
 </section>
+<section title="Changes from 3.2 to 3.5">
+  <t>
+    <list>
+      <t hangText="????">
+      </t>
+    </list>
+  </t>
+</section>
 </section>
 <section title="CMS Options">
 <t>
@@ -391,20 +399,15 @@
  </section>
  <section title="Using Distinguished Names for Internet Mail">
    <t>
-   End-entity certificates MAY contain an Internet mail address as
-   described in <xref target="RFC5280"/>, Section 4.2.1.6.  The email address SHOULD be in
-   the subjectAltName extension, and SHOULD NOT be in the subject
-   distinguished name.
-  </t>
+     End-entity certificates MAY contain an Internet mail address as described in <xref target="RFC5280"/>, Section 4.2.1.6.
+     The email address SHOULD be in the subjectAltName extension, and SHOULD NOT be in the subject distinguished name.
+   </t>
+   
   <t>
-   Receiving agents MUST recognize and accept certificates that contain
-   no email address.  Agents are allowed to provide an alternative
-   mechanism for associating an email address with a certificate that
-   does not contain an email address, such as through the use of the
-   agent's address book, if available.  Receiving agents MUST recognize
-   email addresses in the subjectAltName field.  Receiving agents MUST
-   recognize email addresses in the Distinguished Name field in the PKCS
-   #9 <xref target="RFC2985"/> emailAddress attribute:
+    Receiving agents MUST recognize and accept certificates that contain no email address.
+    Agents are allowed to provide an alternative mechanism for associating an email address with a certificate that does not contain an email address, such as through the use of the agent's address book, if available.
+    Receiving agents MUST recognize email addresses in the subjectAltName field.
+    Receiving agents MUST recognize email addresses in the Distinguished Name field in the PKCS #9 <xref target="RFC2985"/> emailAddress attribute:
   </t>
     <figure>
       <artwork>
@@ -414,33 +417,19 @@ pkcs-9-at-emailAddress OBJECT IDENTIFIER ::=
     </figure>
 
     <t>
-   Note that this attribute MUST be encoded as IA5String and has an
-   upper bound of 255 characters.  The right side of the email address
-   SHOULD be treated as ASCII-case-insensitive.
+      Note that this attribute MUST be encoded as IA5String and has an  upper bound of 255 characters.
+      The right side of the email address SHOULD be treated as ASCII-case-insensitive.
   </t>
   <t>
-   Sending agents SHOULD make the address in the From or Sender header
-   in a mail message match an Internet mail address in the signer's
-   certificate.  Receiving agents MUST check that the address in the
-   From or Sender header of a mail message matches an Internet mail
-   address, if present, in the signer's certificate, if mail addresses
-   are present in the certificate.  A receiving agent SHOULD provide
-   some explicit alternate processing of the message if this comparison
-   fails, which may be to display a message that shows the recipient the
-   addresses in the certificate or other certificate details.
+    Sending agents SHOULD make the address in the From or Sender header in a mail message match an Internet mail address in the signer's certificate.
+    Receiving agents MUST check that the address in the From or Sender header of a mail message matches an Internet mail address, if present, in the signer's certificate, if mail addresses are present in the certificate.
+    A receiving agent SHOULD provide some explicit alternate processing of the message if this comparison fails, which may be to display a message that shows the recipient the addresses in the certificate or other certificate details.
   </t>
   <t>
-   A receiving agent SHOULD display a subject name or other certificate
-   details when displaying an indication of successful or unsuccessful
-   signature verification.
+   A receiving agent SHOULD display a subject name or other certificate details when displaying an indication of successful or unsuccessful signature verification.
   </t>
   <t>
-   All subject and issuer names MUST be populated (i.e., not an empty
-   SEQUENCE) in S/&wj;MIME-compliant X.509 certificates, except that the
-   subject distinguished name (DN) in a user's (i.e., end-entity)
-   certificate MAY be an empty SEQUENCE in which case the subjectAltName
-   extension will include the subject's identifier and MUST be marked as
-   critical.
+   All subject and issuer names MUST be populated (i.e., not an empty SEQUENCE) in S/&wj;MIME-compliant X.509 certificates, except that the subject distinguished name (DN) in a user's (i.e., end-entity) certificate MAY be an empty SEQUENCE in which case the subjectAltName extension will include the subject's identifier and MUST be marked as critical.
   </t>
  </section>
 <section title="Certificate Processing">


### PR DESCRIPTION
Make the organization name reflect the correct IETF working group name
